### PR TITLE
FIX: Read the mailbox after write led state

### DIFF
--- a/src/ok03/led.s
+++ b/src/ok03/led.s
@@ -16,7 +16,9 @@ set_led_state:
 
     str         r1, [r0, #24]       @; overwrite the led state
     add         r0, #8              @; add the channel 8 as the last 4 bits of the message
-    bl          mailbox_write
+    bl          mailbox_write       @; write the message to mailbox
+    mov         r0, #8              @; the channel to read the message from
+    bl          mailbox_read        @; read the message to prevent the FIFO queue to get full
     pop         {pc}                @; return
 
 .section .data

--- a/src/ok03/mailbox.s
+++ b/src/ok03/mailbox.s
@@ -5,12 +5,51 @@
 .section .text
 .global mailbox_write
 mailbox_write:
-    ldr         r1, =0x3f00b880     @; load the hex number =0x3f00b880 into register r1
-                                    @; this is the base address of the mailboxes
+    ldr         r1, =0x3f00b880                 @; load the hex number =0x3f00b880 into register r1
+                                                @; this is the base address of the mailboxes
     wait$:
-        ldr     r2, [r1, #0x38]     @; load r2 with the address of the status for mailbox 1 (ARM -> VC)
-        tst     r2, #0x80000000     @; check if the FIFO queue is full
-        bne     wait$               @; branch to wait$ label if the queue is full
+        ldr     r2, [r1, #0x38]                 @; load r2 with the address of the status for mailbox 1 (ARM -> VC)
+        tst     r2, #0x80000000                 @; check if the FIFO queue is full
+        bne     wait$                           @; branch to wait$ label if the queue is full
 
-    str         r0, [r1, #0x20]     @; put the message into mailbox 1 write register, which is at offset 0x20 from the base address
-    mov         pc, lr              @; return
+    str         r0, [r1, #0x20]                 @; put the message into mailbox 1 write register, which is at offset 0x20 from the base address
+    mov         pc, lr                          @; return
+
+.global mailbox_read
+mailbox_read:
+    push        {lr}                            @; push the address the function should return to
+    mov         r1, r0                          @; save the channel in r1
+    ldr         r0, =0x3f00b880                 @; load mailbox base address into r0
+
+    right_mail$:
+        wait_read$:
+            ldr     r2, [r0, #0x18]             @; get status of mailbox 0 (VC -> ARM)
+            tst     r2, #0x40000000             @; check if the mailbox is empty
+            bne     wait_read$                  @; if VC FIFO queue is empty branch to wait_read
+
+        ldr     r2, [r0]                        @; load the address of response data
+
+        and     r3, r2, #0b1111                 @; extract the channel, the lowest 4 bits
+        teq     r3, r1                          @; check if the response channel is the same we want
+        bne     right_mail$                     @; if the channel is wrong branch to wait_read
+
+    and         r0, r2, #0xfffffff0             @; move the response (top 28 bits of mail) into r0
+    pop         {pc}                            @; return
+    push        {lr}                            @; push the address the function should return to
+    mov         r1, r0                          @; save the channel in r1
+    ldr         r0, =0x3f00b880                 @; load mailbox base address into r0
+
+    right_mail$:
+        wait_read$:
+            ldr     r2, [r0, #0x18]             @; get status of mailbox 0 (VC -> ARM)
+            tst     r2, #0x40000000             @; check if the mailbox is empty
+            bne     wait_read$                  @; if VC FIFO queue is empty branch to wait_read
+
+        ldr     r2, [r0]                        @; load the address of response data
+
+        and     r3, r2, #0b1111                 @; extract the channel, the lowest 4 bits
+        teq     r3, r1                          @; check if the response channel is the same we want
+        bne     right_mail$                     @; if the channel is wrong branch to wait_read
+
+    and         r0, r2, #0xfffffff0             @; move the response (top 28 bits of mail) into r0
+    pop         {pc}                            @; return

--- a/src/ok04/led.s
+++ b/src/ok04/led.s
@@ -16,7 +16,9 @@ set_led_state:
 
     str         r1, [r0, #24]       @; overwrite the led state
     add         r0, #8              @; add the channel 8 as the last 4 bits of the message
-    bl          mailbox_write
+    bl          mailbox_write       @; write the message to mailbox
+    mov         r0, #8              @; the channel to read the message from
+    bl          mailbox_read        @; read the message to prevent the FIFO queue to get full
     pop         {pc}                @; return
 
 .section .data

--- a/src/ok04/mailbox.s
+++ b/src/ok04/mailbox.s
@@ -5,12 +5,33 @@
 .section .text
 .global mailbox_write
 mailbox_write:
-    ldr         r1, =0x3f00b880     @; load the hex number =0x3f00b880 into register r1
-                                    @; this is the base address of the mailboxes
+    ldr         r1, =0x3f00b880             @; load the hex number =0x3f00b880 into register r1
+                                            @; this is the base address of the mailboxes
     wait$:
-        ldr     r2, [r1, #0x38]     @; load r2 with the address of the status for mailbox 1 (ARM -> VC)
-        tst     r2, #0x80000000     @; check if the FIFO queue is full
-        bne     wait$               @; branch to wait$ label if the queue is full
+        ldr     r2, [r1, #0x38]             @; load r2 with the address of the status for mailbox 1 (ARM -> VC)
+        tst     r2, #0x80000000             @; check if the FIFO queue is full
+        bne     wait$                       @; branch to wait$ label if the queue is full
 
-    str         r0, [r1, #0x20]     @; put the message into mailbox 1 write register, which is at offset 0x20 from the base address
-    mov         pc, lr              @; return
+    str         r0, [r1, #0x20]             @; put the message into mailbox 1 write register, which is at offset 0x20 from the base address
+    mov         pc, lr                      @; return
+
+.global mailbox_read
+mailbox_read:
+    push        {lr}                        @; push the address the function should return to
+    mov         r1, r0                      @; save the channel in r1
+    ldr         r0, =0x3f00b880             @; load mailbox base address into r0
+
+    right_mail$:
+        wait_read$:
+            ldr     r2, [r0, #0x18]         @; get status of mailbox 0 (VC -> ARM)
+            tst     r2, #0x40000000         @; check if the mailbox is empty
+            bne     wait_read$              @; if VC FIFO queue is empty branch to wait_read
+
+        ldr     r2, [r0]                    @; load the address of response data
+
+        and     r3, r2, #0b1111             @; extract the channel, the lowest 4 bits
+        teq     r3, r1                      @; check if the response channel is the same we want
+        bne     right_mail$                 @; if the channel is wrong branch to wait_read
+
+    and         r0, r2, #0xfffffff0         @; move the response (top 28 bits of mail) into r0
+    pop         {pc}                        @; return

--- a/src/ok05/led.s
+++ b/src/ok05/led.s
@@ -16,7 +16,9 @@ set_led_state:
 
     str         r1, [r0, #24]       @; overwrite the led state
     add         r0, #8              @; add the channel 8 as the last 4 bits of the message
-    bl          mailbox_write
+    bl          mailbox_write       @; write the message to mailbox
+    mov         r0, #8              @; the channel to read the message from
+    bl          mailbox_read        @; read the message to prevent the FIFO queue to get full
     pop         {pc}                @; return
 
 .section .data

--- a/src/ok05/mailbox.s
+++ b/src/ok05/mailbox.s
@@ -5,12 +5,33 @@
 .section .text
 .global mailbox_write
 mailbox_write:
-    ldr         r1, =0x3f00b880     @; load the hex number =0x3f00b880 into register r1
-                                    @; this is the base address of the mailboxes
+    ldr         r1, =0x3f00b880             @; load the hex number =0x3f00b880 into register r1
+                                            @; this is the base address of the mailboxes
     wait$:
-        ldr     r2, [r1, #0x38]     @; load r2 with the address of the status for mailbox 1 (ARM -> VC)
-        tst     r2, #0x80000000     @; check if the FIFO queue is full
-        bne     wait$               @; branch to wait$ label if the queue is full
+        ldr     r2, [r1, #0x38]             @; load r2 with the address of the status for mailbox 1 (ARM -> VC)
+        tst     r2, #0x80000000             @; check if the FIFO queue is full
+        bne     wait$                       @; branch to wait$ label if the queue is full
 
-    str         r0, [r1, #0x20]     @; put the message into mailbox 1 write register, which is at offset 0x20 from the base address
-    mov         pc, lr              @; return
+    str         r0, [r1, #0x20]             @; put the message into mailbox 1 write register, which is at offset 0x20 from the base address
+    mov         pc, lr                      @; return
+
+.global mailbox_read
+mailbox_read:
+    push        {lr}                        @; push the address the function should return to
+    mov         r1, r0                      @; save the channel in r1
+    ldr         r0, =0x3f00b880             @; load mailbox base address into r0
+
+    right_mail$:
+        wait_read$:
+            ldr     r2, [r0, #0x18]         @; get status of mailbox 0 (VC -> ARM)
+            tst     r2, #0x40000000         @; check if the mailbox is empty
+            bne     wait_read$              @; if VC FIFO queue is empty branch to wait_read
+
+        ldr     r2, [r0]                    @; load the address of response data
+
+        and     r3, r2, #0b1111             @; extract the channel, the lowest 4 bits
+        teq     r3, r1                      @; check if the response channel is the same we want
+        bne     right_mail$                 @; if the channel is wrong branch to wait_read
+
+    and         r0, r2, #0xfffffff0         @; move the response (top 28 bits of mail) into r0
+    pop         {pc}                        @; return

--- a/src/screen01/led.s
+++ b/src/screen01/led.s
@@ -17,7 +17,9 @@ SetACTLedState:
     str         r1, [r0, #24]       @; overwrite the led state
 
     mov         r1, #8              @; set mailbox channel
-    bl          MailboxWrite
+    bl          MailboxWrite        @; write the message
+    mov         r0, #8              @; the channel to read the message from
+    bl          MailboxRead         @; read the message to prevent the FIFO queue to get full
     pop         {pc}                @; return
 
 .section .data


### PR DESCRIPTION
We need this to prevent the mailbox 0 (VC -> ARM) FIFO queue to get full and never turn off the led